### PR TITLE
feature/disableSetAccessControlAllowOrigin

### DIFF
--- a/EventListener/CorsListener.php
+++ b/EventListener/CorsListener.php
@@ -120,6 +120,10 @@ class CorsListener
             $response->headers->set('Access-Control-Max-Age', $options['max_age']);
         }
 
+        if (0 === count($options['allow_origin'])) {
+            return $response;
+        }
+
         if (!$this->checkOrigin($request, $options)) {
             $response->headers->set('Access-Control-Allow-Origin', 'null');
 

--- a/Tests/CorsListenerTest.php
+++ b/Tests/CorsListenerTest.php
@@ -160,4 +160,27 @@ class CorsListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($event->getResponse());
     }
+
+    public function testPreflightedRequestWithoutOriginDoesNotReturnOriginHeader()
+    {
+        $options = array(
+            'allow_origin' => array(),
+            'allow_methods' => array('OPTIONS', 'POST'),
+        );
+
+        // preflight
+        $req = Request::create('/foo', 'OPTIONS');
+        $req->headers->set('Origin', 'http://example.com');
+        //$req->headers->set('Access-Control-Request-Method', 'Link');
+
+        $dispatcher = m::mock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $event = new GetResponseEvent(m::mock('Symfony\Component\HttpKernel\HttpKernelInterface'), $req, HttpKernelInterface::MASTER_REQUEST);
+        $this->getListener($dispatcher, $options)->onKernelRequest($event);
+        $resp = $event->getResponse();
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $resp);
+        $this->assertEquals(200, $resp->getStatusCode());
+        $this->assertNull($resp->headers->get('Access-Control-Allow-Origin'));
+        $this->assertEquals('OPTIONS, POST', $resp->headers->get('Access-Control-Allow-Methods'));
+    }
 }


### PR DESCRIPTION
- Added the possibility to disable having to set the header "Access-Control-Allow-Origin" by setting the option to false - allow_origin: false
- Added test testPreflightedRequestWithoutOriginDoesNotReturnOriginHeader